### PR TITLE
Update to be able to deploy without types in root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,51 +59,11 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@types/body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
-    },
-    "@types/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-      "dev": true,
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.16.11",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.11.tgz",
-      "integrity": "sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/range-parser": "*"
-      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -115,12 +75,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -139,22 +93,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
-    },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
-    },
-    "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
-      }
     },
     "aggregate-error": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/edwinthinks/inspiration-ipsum#readme",
   "devDependencies": {
-    "@types/express": "^4.17.2",
     "husky": "^3.0.9",
     "lint-staged": "^9.4.3",
     "prettier": "^1.19.1"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -28,7 +28,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
       "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -44,7 +43,6 @@
       "version": "3.4.32",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -65,7 +63,6 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
       "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -76,7 +73,6 @@
       "version": "4.16.11",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.11.tgz",
       "integrity": "sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -91,8 +87,7 @@
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-      "dev": true
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -103,20 +98,17 @@
     "@types/node": {
       "version": "12.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
-      "dev": true
+      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
       "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"

--- a/server/package.json
+++ b/server/package.json
@@ -22,11 +22,11 @@
   "homepage": "https://github.com/edwinthinks/inspiration-ipsum#readme",
   "dependencies": {
     "express": "^4.17.1",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "@types/express": "^4.17.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.4",
-    "@types/express": "^4.17.2",
     "@types/mocha": "^5.2.7",
     "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "^2.6.1",


### PR DESCRIPTION
Resolve an issue that made it seem like I needed @types/express in the root directory. What happens is if heroku deploying it will remove dependencies.